### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+EXPOSE 3000
+
+RUN apk --no-cache add git && go get github.com/maklesoft/padlock-cloud && apk del git
+
+ENTRYPOINT padlock-cloud --notify-errors ${NOTIFY_EMAIL}  --db-path=/db --email-server ${MAIL_SERVER} --email-port ${MAIL_PORT} --email-user ${MAIL_USER} --email-password ${MAIL_PASSWORD} runserver --cors --base-url ${BASE_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ EXPOSE 3000
 
 RUN apk --no-cache add git && go get github.com/maklesoft/padlock-cloud && apk del git
 
-ENTRYPOINT padlock-cloud --notify-errors ${NOTIFY_EMAIL}  --db-path=/db --email-server ${MAIL_SERVER} --email-port ${MAIL_PORT} --email-user ${MAIL_USER} --email-password ${MAIL_PASSWORD} runserver --cors --base-url ${BASE_URL}
+ENTRYPOINT padlock-cloud  --db-path=/db runserver --cors

--- a/README.md
+++ b/README.md
@@ -152,3 +152,16 @@ knows where to find these assets. You can do this via the `--assets-path`
 option. By default, the server will look for the templates under
 `$GOPATH/src/github.com/maklesoft/padlock-cloud/assets/templates` which is
 where they will usually be if you installed `padlock-cloud` via `go get`.
+
+## Usage with docker
+
+```bash
+docker volume create --name padlock
+docker run -p 443:3000 --name padlock-cloud \
+   -v padlock:/db --restart always \
+  -e BASE_URL=<BASE_URL> -e NOTIFY_EMAIL=<NOTIFY_EMAIL> \
+  -e MAIL_SERVER=<MAIL_SERVER> -e MAIL_PORT=<MAIL_PORT> \
+  -e MAIL_USER=<MAIL_USER> -e MAIL_PASSWORD=<MAIL_PASSWORD> \
+  -v <path-to-certs>:/etc/ssl/certs:ro  \
+  -d padlock/padlock-cloud --tls-cert <path-to-cert> --tls-key <path-to-key>
+```

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ where they will usually be if you installed `padlock-cloud` via `go get`.
 docker volume create --name padlock
 docker run -p 443:3000 --name padlock-cloud \
    -v padlock:/db --restart always \
-  -e BASE_URL=<BASE_URL> -e NOTIFY_EMAIL=<NOTIFY_EMAIL> \
-  -e MAIL_SERVER=<MAIL_SERVER> -e MAIL_PORT=<MAIL_PORT> \
-  -e MAIL_USER=<MAIL_USER> -e MAIL_PASSWORD=<MAIL_PASSWORD> \
+  -e PC_BASE_URL=<BASE_URL> -e PC_NOTIFY_ERRORS=<NOTIFY_EMAIL> \
+  -e PC_EMAIL_SERVER=<MAIL_SERVER> -e PC_EMAIL_PORT=<MAIL_PORT> \
+  -e PC_EMAIL_USER=<MAIL_USER> -e PC_EMAIL_PASSWORD=<MAIL_PASSWORD> \
   -v <path-to-certs>:/etc/ssl/certs:ro  \
   -d padlock/padlock-cloud --tls-cert <path-to-cert> --tls-key <path-to-key>
 ```


### PR DESCRIPTION
I use it for months (https://hub.docker.com/r/weboaks/padlock/), and it works like a charm, but an official image could be better.

Once the pr is merged, you only need to create a padlock organization on https://hub.docker.com and create a padlock-cloud image with an automated build linked to this repo. Let me know if you want me to create the image and add you to the organization.