### PR TITLE
Fix: Install ca-certificates as they are needed to validate certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN addgroup -g ${gid} -S ${group} &&\
 RUN mkdir -p ${WORKDIR} && mkdir -p ${WORKDIR}/db && mkdir -p ${WORKDIR}/logs &&\
     mkdir -p ${WORKDIR}/ssl && touch ${WORKDIR}/logs/info.log && touch ${WORKDIR}/logs/error.log
 
-RUN apk update && apk --no-cache add su-exec
+RUN apk update && apk --no-cache add su-exec ca-certificates
 
 WORKDIR ${WORKDIR}
 


### PR DESCRIPTION
Without ca-certificates installed auth_token:request fails (no mail is sent) with:
```
ERROR: 2018/12/14 21:51:39 [IP] POST /login/
***STACK TRACE***
x509: certificate signed by unknown authority
***REQUEST***
POST /login/ HTTP/1.1
Host: [HOST]
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US,en;q=0.5
Content-Length: [LENGTH]
Content-Type: application/x-www-form-urlencoded
Cookie: [COOKIE]
Dnt: 1
Referer: https://[HOST]/login/
Upgrade-Insecure-Requests: 1
User-Agent: [USER-AGENT]
X-Forwarded-For: [IP]
X-Forwarded-Host: [HOST]
X-Forwarded-Port: 443
X-Forwarded-Proto: https
X-Forwarded-Server: [HASH]
X-Real-Ip: [IP]
```